### PR TITLE
Stop overriding user-formatted chat messages.

### DIFF
--- a/dracula.css
+++ b/dracula.css
@@ -285,7 +285,6 @@ input {
 }
 
 .channel-list-item[data-type=lobby],
-.irc-bold,
 #chat .toggle-content .head {
   font-weight: 500;
 }
@@ -672,9 +671,5 @@ body #chat .toggle-content .thumb {
 
 /* Disable highlighted words in between text */
 #chat .content span[class*="irc-"] {
-  background-color: inherit;
   font-family: inherit;
-  font-style: inherit;
-  font-weight: inherit;
-  text-decoration: inherit;
 }


### PR DESCRIPTION
Stop overriding user formatting, allowing italic, bold, underline, background colour etc.

From:
![Screenshot 2023-07-28 at 16 23 51](https://github.com/dracula/thelounge/assets/1727812/123302ae-907f-411f-925a-a15363d3b0a1)

To:
![Screenshot 2023-07-28 at 16 24 30](https://github.com/dracula/thelounge/assets/1727812/25b4021b-6d23-4610-aeec-feeb7d67f02a)
