### PR TITLE
Add scrollbar-color with Current line pallet to body

### DIFF
--- a/dracula.css
+++ b/dracula.css
@@ -11,6 +11,7 @@ body {
   -webkit-font-smoothing: subpixel-antialiased;
   /* text-rendering: geometricPrecision; */
   text-size-adjust: none;
+  scrollbar-color: rgba(68,71,90,100) transparent
 }
 
 /* General vars */


### PR DESCRIPTION
Add scrollbar-color with the Current line pallet so the scrollbars will have it as a background.

> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

Before:
![image](https://github.com/dracula/thelounge/assets/1533244/747fe37e-42b4-4902-89c0-39f319d60825)

After:
![image](https://github.com/dracula/thelounge/assets/1533244/c3d1629e-933c-44a9-9c78-0a072df407e0)
